### PR TITLE
Allow to choose an index for tagged collection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -19,16 +19,30 @@ namespace Symfony\Component\DependencyInjection\Argument;
 class TaggedIteratorArgument extends IteratorArgument
 {
     private $tag;
+    private $indexAttribute;
+    private $defaultIndexMethod;
 
-    public function __construct(string $tag)
+    public function __construct(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null)
     {
         parent::__construct(array());
 
         $this->tag = $tag;
+        $this->indexAttribute = $indexAttribute;
+        $this->defaultIndexMethod = $defaultIndexMethod;
     }
 
     public function getTag()
     {
         return $this->tag;
+    }
+
+    public function getIndexAttribute(): ?string
+    {
+        return $this->indexAttribute;
+    }
+
+    public function getDefaultIndexMethod(): ?string
+    {
+        return $this->defaultIndexMethod;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveTaggedIteratorArgumentPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveTaggedIteratorArgumentPass.php
@@ -31,7 +31,7 @@ class ResolveTaggedIteratorArgumentPass extends AbstractRecursivePass
             return parent::processValue($value, $isRoot);
         }
 
-        $value->setValues($this->findAndSortTaggedServices($value->getTag(), $this->container));
+        $value->setValues($this->findAndSortTaggedServices($value->getTag(), $this->container, $value->getIndexAttribute(), $value->getDefaultIndexMethod()));
 
         return $value;
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -116,9 +116,9 @@ function iterator(array $values): IteratorArgument
 /**
  * Creates a lazy iterator by tag name.
  */
-function tagged(string $tag): TaggedIteratorArgument
+function tagged(string $tag, string $indexAttribute = null, string $defaultIndexMethod = null): TaggedIteratorArgument
 {
-    return new TaggedIteratorArgument($tag);
+    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod);
 }
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -706,11 +706,13 @@ class YamlFileLoader extends FileLoader
                 }
             }
             if ('tagged' === $value->getTag()) {
-                if (!\is_string($argument) || !$argument) {
-                    throw new InvalidArgumentException(sprintf('"!tagged" tag only accepts non empty string in "%s".', $file));
+                if (\is_string($argument) && $argument) {
+                    return new TaggedIteratorArgument($argument);
+                } elseif (\is_array($argument) && isset($argument['name']) && $argument['name']) {
+                    return new TaggedIteratorArgument($argument['name'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null);
+                } else {
+                    throw new InvalidArgumentException(sprintf('"!tagged" tag only accepts a non empty string or an array with a key "name" in "%s".', $file));
                 }
-
-                return new TaggedIteratorArgument($argument);
             }
             if ('service' === $value->getTag()) {
                 if ($isParameter) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | tbd
| Fixed tickets | #
| License       | MIT
| Doc PR        | symfony/symfony-docs#tbd

Add a way to specify an index based on a tag attribute when injecting a tag collection into services, but also a a way to fallback to a static method on the service class.

```yaml
!tagged {name: 'tag_name', index_by: 'tag_attribute_name', default_index_method: 'static_method'}
```

Tasks

- [x] Support PHP loader
- [x] Support YAML loader
- [ ] Support XML loader (update XSD)
- [ ] Add tests
